### PR TITLE
Release version 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-human-layer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "expect-test",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-human-layer"
-version = "0.1.0"
+version = "0.1.1"
 description = "A human-friendly tracing console output layer"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Update version to 0.1.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.