### PR TITLE
Release version 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-human-layer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "expect-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [package]
 name = "tracing-human-layer"
-version = "0.1.1"
+version = "0.1.2"
 description = "A human-friendly tracing console output layer"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Update version to 0.1.2 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.