### PR TITLE
Write to Stderr by default

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -11,9 +11,9 @@ struct Opts {
     /// Use colored output.
     #[arg(long)]
     color: bool,
-    /// Write output to stderr.
+    /// Write output to stdout.
     #[arg(long)]
-    stderr: bool,
+    stdout: bool,
 }
 
 fn main() {
@@ -25,18 +25,18 @@ fn main() {
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .with_color_output(
             opts.color
-                || supports_color::on(if opts.stderr {
-                    Stream::Stderr
-                } else {
+                || supports_color::on(if opts.stdout {
                     Stream::Stdout
+                } else {
+                    Stream::Stderr
                 })
                 .map(|level| level.has_basic)
                 .unwrap_or_default(),
         );
 
-    if opts.stderr {
+    if opts.stdout {
         registry
-            .with(layer.with_output_writer(std::io::stderr()))
+            .with(layer.with_output_writer(std::io::stdout()))
             .init();
     } else {
         registry.with(layer).init();

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::io::Stdout;
+use std::io::Stderr;
 use std::io::Write;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -24,7 +24,7 @@ use crate::Style;
 use crate::StyledSpanFields;
 
 /// A human-friendly [`tracing_subscriber::Layer`].
-pub struct HumanLayer<W = Stdout> {
+pub struct HumanLayer<W = Stderr> {
     /// We print blank lines before and after long log messages to help visually separate them.
     ///
     /// This becomes an issue if two long log messages are printed one after another.
@@ -56,13 +56,13 @@ impl Default for HumanLayer {
             last_event_was_long: Default::default(),
             span_events: FmtSpan::NONE,
             color_output: ShouldColor::Always,
-            output_writer: Mutex::new(std::io::stdout()),
+            output_writer: Mutex::new(std::io::stderr()),
         }
     }
 }
 
 impl HumanLayer {
-    /// Construct a new [`HumanLayer`] that writes to [`Stdout`].
+    /// Construct a new [`HumanLayer`] that writes to [`Stderr`].
     pub fn new() -> Self {
         Self::default()
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -5,7 +5,7 @@ use test_harness::Example;
 fn test_basic_output() {
     let output = Example::name("demo").output().unwrap();
 
-    let stdout = expect![[r#"
+    let stderr = expect![[r#"
         TRACE Trace event.
         DEBUG Debug event.
         • Info event. field="field-value"
@@ -76,8 +76,8 @@ fn test_basic_output() {
         • close
           in my-span{path="my/cool/path.txt"}
     "#]];
-    stdout.assert_eq(&output.stdout);
-
-    let stderr = expect![[""]];
     stderr.assert_eq(&output.stderr);
+
+    let stdout = expect![[""]];
+    stdout.assert_eq(&output.stdout);
 }

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -5,7 +5,7 @@ use test_harness::Example;
 fn test_color() {
     let output = Example::name("demo").arg("--color").output().unwrap();
 
-    let stdout = expect![[r#"
+    let stderr = expect![[r#"
         [35mTRACE [0m[2mTrace event.[0m
         [34mDEBUG [0m[2mDebug event.[0m
         [32m• [0mInfo event. [1mfield[0m="field-value"
@@ -76,8 +76,8 @@ fn test_color() {
         [32m• [0mclose
           [2min [0mmy-span{[1mpath[0m="my/cool/path.txt"}
     "#]];
-    stdout.assert_eq(&output.stdout);
-
-    let stderr = expect![[""]];
     stderr.assert_eq(&output.stderr);
+
+    let stdout = expect![[""]];
+    stdout.assert_eq(&output.stdout);
 }

--- a/tests/output_stream.rs
+++ b/tests/output_stream.rs
@@ -2,13 +2,13 @@ use expect_test::expect;
 use test_harness::Example;
 
 #[test]
-fn test_output_stream_stderr() {
-    let output = Example::name("demo").arg("--stderr").output().unwrap();
+fn test_output_stream_stdout() {
+    let output = Example::name("demo").arg("--stdout").output().unwrap();
 
-    let stdout = expect![""];
-    stdout.assert_eq(&output.stdout);
+    let stderr = expect![""];
+    stderr.assert_eq(&output.stderr);
 
-    let stderr = expect![[r#"
+    let stdout = expect![[r#"
         TRACE Trace event.
         DEBUG Debug event.
         • Info event. field="field-value"
@@ -79,5 +79,5 @@ fn test_output_stream_stderr() {
         • close
           in my-span{path="my/cool/path.txt"}
     "#]];
-    stderr.assert_eq(&output.stderr);
+    stdout.assert_eq(&output.stdout);
 }


### PR DESCRIPTION
???

I don't know why I thought logs go on Stdout.