### PR TITLE
nextest: kill tests after 4 minutes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+# https://nexte.st/book/configuration.html
+
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 4 }


### PR DESCRIPTION
I would make the timeout like 1 second but I think `tests/basic.rs` may build a whole example binary...