### PR TITLE
bench: force line-wrapping

### DIFF
--- a/benches/format_event.rs
+++ b/benches/format_event.rs
@@ -19,7 +19,7 @@ fn emit_span_and_event() {
         event_field = "event_field_value",
         kind = "silly",
         puppy = "doggy",
-        "inspecting pawbs and other stuff and other stuff and other stuff"
+        "inspecting pawbs and other stuff and other stuff and other stuff and this and that and the other thing"
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@
 //! TL;DR: Logging performance is dominated by the cost of writing to stderr.
 //!
 //! I haven't done too much performance work on `tracing-human-layer`, but I do have a couple
-//! benchmarks. It seems to take 1.5-4µs to format an event (including emitting a span and event),
+//! benchmarks. It seems to take 2-6µs to format an event (including emitting a span and event),
 //! with the exact cost depending on whether or not color output
 //! ([`HumanLayer::with_color_output`]) or text wrapping ([`HumanLayer::with_textwrap_options`])
 //! is enabled.
 //!
-//! Formatting an event _and writing it to stderr_ takes 25µs, so actually showing the logs to the
-//! user is about 6.5× slower than just formatting them.
+//! Formatting an event _and writing it to stderr_ takes 20µs, so actually showing the logs to the
+//! user is about 3.5× slower than just formatting them.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Emitting a longer `message` makes the message actually get wrapped.