### PR TITLE
6% perf gain: Don't write fields to strings preemptively

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -378,7 +378,7 @@ mod tests {
                 textwrap_options: Some((&TextWrapOptionsOwned::new()).into()),
             },
             expect![[r#"
-                [35mTRACE [0m[2mFine-grained tracing info [1;2mfavorite_doggy_sound[0m[2m=awooooooo[0m[0m
+                [35mTRACE [0m[2mFine-grained tracing info [1;2mfavorite_doggy_sound[0m[2m=[0m[2mawooooooo[0m[0m
             "#]],
         );
     }
@@ -400,7 +400,7 @@ mod tests {
                 textwrap_options: Some((&TextWrapOptionsOwned::new()).into()),
             },
             expect![[r#"
-                [34mDEBUG [0m[2mDebugging info [1;2mpuppy[0m[2m=pawbeans[0m[0m
+                [34mDEBUG [0m[2mDebugging info [1;2mpuppy[0m[2m=[0m[2mpawbeans[0m[0m
             "#]],
         );
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -133,12 +133,19 @@ pub struct Style {
 }
 
 impl Style {
-    pub(crate) fn style_field(&self, color: ShouldColor, name: &str, value: &str) -> String {
-        format!(
-            "{name}{value}",
-            name = name.colored(color, self.field_name),
-            value = format!("={value}").colored(color, self.field_value),
-        )
+    pub(crate) fn style_field<'a>(
+        &'a self,
+        color: ShouldColor,
+        name: &'a str,
+        value: &'a str,
+    ) -> StyledField<'a> {
+        StyledField {
+            color,
+            name,
+            name_style: self.field_name,
+            value,
+            value_style: self.field_value,
+        }
     }
 
     /// First-line indent text.
@@ -223,5 +230,22 @@ where
             ShouldColor::Always => self.style.style(&self.inner).fmt(f),
             ShouldColor::Never => self.inner.fmt(f),
         }
+    }
+}
+
+pub(crate) struct StyledField<'a> {
+    color: ShouldColor,
+    name: &'a str,
+    name_style: OwoStyle,
+    value: &'a str,
+    value_style: OwoStyle,
+}
+
+impl Display for StyledField<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name.colored(self.color, self.name_style))?;
+        write!(f, "{}", '='.colored(self.color, self.value_style))?;
+        write!(f, "{}", self.value.colored(self.color, self.value_style))?;
+        Ok(())
     }
 }


### PR DESCRIPTION
This seems to improve performance by 5.7%!

```
format event/colors, wrapping, stderr
    time:   [11.696 µs 11.714 µs 11.737 µs]
    change: [-6.2772% -5.7379% -5.1220%] (p = 0.00 < 0.05)
format event/colors, wrapping
    time:   [5.2662 µs 5.2711 µs 5.2747 µs]
    change: [-14.121% -13.943% -13.777%] (p = 0.00 < 0.05)
format event/no colors, wrapping
    time:   [5.1020 µs 5.1102 µs 5.1164 µs]
    change: [-10.160% -10.017% -9.8873%] (p = 0.00 < 0.05)
format event/colors, no wrapping
    time:   [1.7943 µs 1.7968 µs 1.8006 µs]
    change: [-25.048% -24.892% -24.716%] (p = 0.00 < 0.05)
format event/no colors, no wrapping
    time:   [1.4897 µs 1.4916 µs 1.4947 µs]
    change: [-22.072% -21.960% -21.832%] (p = 0.00 < 0.05)
```